### PR TITLE
docs(README): fix link in "Import tRPC API" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _Easily set up a local development environment_
 
 There are 2 ways to import tRPC API types from backend repo:
 
-1. Install npm package `npm i trpc-api-boilerplate` (currently [set](https://github.com/mkosir/trpc-fe-boilerplate-vite/blob/main/src/common/trpc-api-boilerplate/client/index.ts#L4) as a default option)
+1. Install npm package `npm i trpc-api-boilerplate` (currently [set](https://github.com/mkosir/trpc-fe-boilerplate-vite/blob/main/src/common/trpc-api-boilerplate/client/index.ts#L2) as a default option)
 2. Run npm script `npm run trpc-api-import` ([uncomment line](https://github.com/mkosir/trpc-fe-boilerplate-vite/blob/main/src/common/trpc-api-boilerplate/client/index.ts#L7))
 
 ## Example Repo


### PR DESCRIPTION
Fix an incorrect link in the  "Import tRPC API" section of the `README.md`.